### PR TITLE
Git push typo fix (from upstream).

### DIFF
--- a/README.md
+++ b/README.md
@@ -664,7 +664,7 @@ git commit -m "Description of your changes."
 
 **Step 4:** Push your changes to GitHub
 ```
-git push origin/master
+git push origin master
 ```
 
 


### PR DESCRIPTION
Merge in a fix for a typo in the `git push` section, from the upstream branch.